### PR TITLE
Fix JSON key for LocationLink.originSelectionRange

### DIFF
--- a/protocol_3_16/base-structures.go
+++ b/protocol_3_16/base-structures.go
@@ -111,7 +111,7 @@ type LocationLink struct {
 	 * Used as the underlined span for mouse interaction. Defaults to the word
 	 * range at the mouse position.
 	 */
-	OriginSelectionRange *Range `json:"uri,omitempty"`
+	OriginSelectionRange *Range `json:"originSelectionRange,omitempty"`
 
 	/**
 	 * The target resource identifier of this link.
@@ -131,7 +131,7 @@ type LocationLink struct {
 	 * followed, e.g the name of a function. Must be contained by the the
 	 * `targetRange`. See also `DocumentSymbol#range`
 	 */
-	TargetSelectionRange Range `json:"targetSelectionRage"`
+	TargetSelectionRange Range `json:"targetSelectionRange"`
 }
 
 // https://microsoft.github.io/language-server-protocol/specification#diagnostic


### PR DESCRIPTION
The JSON key was `uri` instead of `originSelectionRange`.

(BTW I've been using `glsp` in this PR, if you're interested: https://github.com/mickael-menu/zk/pull/21)