### PR TITLE
changed textDocument/color to textDocument/documentColor

### DIFF
--- a/protocol_3_16/language-features.go
+++ b/protocol_3_16/language-features.go
@@ -2074,7 +2074,7 @@ type DocumentColorRegistrationOptions struct {
 	DocumentColorOptions
 }
 
-const MethodTextDocumentColor = Method("textDocument/color")
+const MethodTextDocumentColor = Method("textDocument/documentColor")
 
 type TextDocumentColorFunc func(context *glsp.Context, params *DocumentColorParams) ([]ColorInformation, error)
 


### PR DESCRIPTION
fix method name for textDocument/documentColor
fixes #13 