### PR TITLE
Fix semanticTokens/refresh

### DIFF
--- a/protocol_3_16/handler.go
+++ b/protocol_3_16/handler.go
@@ -36,6 +36,7 @@ type Handler struct {
 	WorkspaceDidRenameFiles            WorkspaceDidRenameFilesFunc
 	WorkspaceWillDeleteFiles           WorkspaceWillDeleteFilesFunc
 	WorkspaceDidDeleteFiles            WorkspaceDidDeleteFilesFunc
+	WorkspaceSemanticTokensRefresh     WorkspaceSemanticTokensRefreshFunc
 
 	// Text Document Synchronization
 	TextDocumentDidOpen           TextDocumentDidOpenFunc
@@ -78,7 +79,6 @@ type Handler struct {
 	TextDocumentSemanticTokensFull      TextDocumentSemanticTokensFullFunc
 	TextDocumentSemanticTokensFullDelta TextDocumentSemanticTokensFullDeltaFunc
 	TextDocumentSemanticTokensRange     TextDocumentSemanticTokensRangeFunc
-	TextDocumentSemanticTokensRefresh   TextDocumentSemanticTokensRefreshFunc
 	TextDocumentLinkedEditingRange      TextDocumentLinkedEditingRangeFunc
 	TextDocumentMoniker                 TextDocumentMonikerFunc
 
@@ -683,11 +683,11 @@ func (self *Handler) Handle(context *glsp.Context) (r any, validMethod bool, val
 			}
 		}
 
-	case MethodTextDocumentSemanticTokensRefresh:
-		if self.TextDocumentSemanticTokensRefresh != nil {
+	case MethodWorkspaceSemanticTokensRefresh:
+		if self.WorkspaceSemanticTokensRefresh != nil {
 			validMethod = true
 			validParams = true
-			err = self.TextDocumentSemanticTokensRefresh(context)
+			err = self.WorkspaceSemanticTokensRefresh(context)
 		}
 
 	case MethodTextDocumentLinkedEditingRange:

--- a/protocol_3_16/language-features.go
+++ b/protocol_3_16/language-features.go
@@ -3089,23 +3089,6 @@ type SemanticTokensRangeParams struct {
 	Range Range `json:"range"`
 }
 
-const MethodTextDocumentSemanticTokensRefresh = Method("textDocument/semanticTokens/refresh")
-
-type TextDocumentSemanticTokensRefreshFunc func(context *glsp.Context) error
-
-type SemanticTokensWorkspaceClientCapabilities struct {
-	/**
-	 * Whether the client implementation supports a refresh request sent from
-	 * the server to the client.
-	 *
-	 * Note that this event is global and will force the client to refresh all
-	 * semantic tokens currently shown. It should be used with absolute care
-	 * and is useful for situation where a server for example detect a project
-	 * wide change that requires such a calculation.
-	 */
-	RefreshSupport *bool `json:"refreshSupport,omitempty"`
-}
-
 // https://microsoft.github.io/language-server-protocol/specifications/specification-3-16#textDocument_linkedEditingRange
 
 type LinkedEditingRangeClientCapabilities struct {

--- a/protocol_3_16/workspace.go
+++ b/protocol_3_16/workspace.go
@@ -574,3 +574,21 @@ type FileDelete struct {
 const MethodWorkspaceDidDeleteFiles = Method("workspace/didDeleteFiles")
 
 type WorkspaceDidDeleteFilesFunc func(context *glsp.Context, params *DeleteFilesParams) error
+
+// https://microsoft.github.io/language-server-protocol/specifications/specification-3-16/#textDocument_semanticTokens
+const MethodWorkspaceSemanticTokensRefresh = Method("workspace/semanticTokens/refresh")
+
+type WorkspaceSemanticTokensRefreshFunc func(context *glsp.Context) error
+
+type SemanticTokensWorkspaceClientCapabilities struct {
+	/**
+	 * Whether the client implementation supports a refresh request sent from
+	 * the server to the client.
+	 *
+	 * Note that this event is global and will force the client to refresh all
+	 * semantic tokens currently shown. It should be used with absolute care
+	 * and is useful for situation where a server for example detect a project
+	 * wide change that requires such a calculation.
+	 */
+	RefreshSupport *bool `json:"refreshSupport,omitempty"`
+}


### PR DESCRIPTION
The `MethodTextDocumentSemanticTokensRefresh` is not properly labeled and queries an `undefined` method, as it is a `workspace` scoped function, not a `TextDocument` one.

Spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#semanticTokensWorkspaceClientCapabilities

Fixes an `undefined method` error.
This fix is currently tested and used on a personal language server

Signed-off-by: guillaume