### PR TITLE
Add method to get stdio connection

### DIFF
--- a/server/stdio.go
+++ b/server/stdio.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"os"
+
+	"github.com/sourcegraph/jsonrpc2"
 )
 
 func (self *Server) RunStdio() error {
@@ -9,6 +11,10 @@ func (self *Server) RunStdio() error {
 	self.serveStream(stdrwc{})
 	self.Log.Info("stdin/stdout connection closed")
 	return nil
+}
+
+func (self *Server) GetStdio() *jsonrpc2.Conn {
+	return self.getStreamConn(stdrwc{})
 }
 
 type stdrwc struct{}


### PR DESCRIPTION
When using this to build a language server, I wanted to send notifications async.

Instead of passing around the context from individual methods, it made more sense to just keep the original connection.

Also, this method makes it possible to implement graceful shutdowns