### PR TITLE
fixed SemanticTokensRangeParams json unmarshalling

### DIFF
--- a/protocol_3_16/language-features.go
+++ b/protocol_3_16/language-features.go
@@ -3081,7 +3081,7 @@ type SemanticTokensRangeParams struct {
 	/**
 	 * The text document.
 	 */
-	TextDocument TextDocumentIdentifier `json:"tokenTypes"`
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
 
 	/**
 	 * The range the semantic tokens are requested for.


### PR DESCRIPTION
I implemented textDocument/semanticTokens/range on my LS and was getting empty params.TextDocument.URI.
I fixed this on my fork and it was indeed the reason for the problem.
Maybe it was a typo? Surprisingly few people must use the range feature if noone noticed it in that case :).