### PR TITLE
exposed the websocket interface to make it more customizable

### DIFF
--- a/server/serve.go
+++ b/server/serve.go
@@ -27,7 +27,7 @@ func (self *Server) getWebSocketConn(socket *websocket.Conn) *jsonrpc2.Conn {
 	return jsonrpc2.NewConn(self.Context, wsjsonrpc2.NewObjectStream(socket), handler, connectionOptions...)
 }
 
-func (self *Server) serveWebSocket(socket *websocket.Conn) {
+func (self *Server) ServeWebSocket(socket *websocket.Conn) {
 	<-self.getWebSocketConn(socket).DisconnectNotify()
 }
 

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -26,7 +26,7 @@ func (self *Server) RunWebSocket(address string) error {
 		connectionId := connectionCount
 
 		self.Log.Infof("received incoming WebSocket connection #%d", connectionId)
-		self.serveWebSocket(connection)
+		self.ServeWebSocket(connection)
 		self.Log.Infof("WebSocket connection #%d closed", connectionId)
 	})
 


### PR DESCRIPTION
In an online playground I am currently developing (https://github.com/DDP-Projekt/Spielplatz) I am using my fork of this repos with this little modification to make the language server work with an arbitrary websocket connection.

Maybe you want to incorporate this change into the main repo, maybe not.
If not, I'm fine just using my fork.

Example usage: https://github.com/DDP-Projekt/Spielplatz/blob/main/server/server.go#L120C12-L120C26