### PR TITLE
Correctly implement `json.Marshaler` interface to fix diagnostic code deserialisation bug

### DIFF
--- a/protocol_3_16/base-protocol.go
+++ b/protocol_3_16/base-protocol.go
@@ -38,12 +38,12 @@ type IntegerOrString struct {
 }
 
 // ([json.Marshaler] interface)
-func (self IntegerOrString) MarshalJSON() ([]byte, error) {
+func (self *IntegerOrString) MarshalJSON() ([]byte, error) {
 	return json.Marshal(self.Value)
 }
 
 // json.Unmarshaler interface
-func (self IntegerOrString) UnmarshalJSON(data []byte) error {
+func (self *IntegerOrString) UnmarshalJSON(data []byte) error {
 	var value Integer
 	if err := json.Unmarshal(data, &value); err == nil {
 		self.Value = value


### PR DESCRIPTION
before:

![image](https://github.com/tliron/glsp/assets/259697/06ba3369-2c1b-437d-a427-8e732e798d33)

after:

![image](https://github.com/tliron/glsp/assets/259697/b630852d-a881-4e41-9add-d3e641cd4b3b)
