### PR TITLE
feat(protocol): Add custom request handling

### DIFF
--- a/protocol_3_16/custom.go
+++ b/protocol_3_16/custom.go
@@ -1,0 +1,15 @@
+package protocol
+
+import (
+	"encoding/json"
+
+	"github.com/tliron/glsp"
+)
+
+type CustomRequestHandler struct {
+	Method string
+	Func   CustomRequestFunc
+	params json.RawMessage
+}
+
+type CustomRequestFunc func(context *glsp.Context, params json.RawMessage) error

--- a/protocol_3_16/handler.go
+++ b/protocol_3_16/handler.go
@@ -82,6 +82,9 @@ type Handler struct {
 	TextDocumentLinkedEditingRange      TextDocumentLinkedEditingRangeFunc
 	TextDocumentMoniker                 TextDocumentMonikerFunc
 
+	// Custom Request/Notification
+	CustomRequest []CustomRequestHandler
+
 	initialized bool
 	lock        sync.Mutex
 }
@@ -709,9 +712,30 @@ func (self *Handler) Handle(context *glsp.Context) (r any, validMethod bool, val
 				r, err = self.TextDocumentMoniker(context, &params)
 			}
 		}
+
+	default:
+		if self.CustomRequest != nil {
+			if handler, ok := self.FindCustomRequestHandler(context.Method); ok {
+				validMethod = true
+				if err = json.Unmarshal(context.Params, &handler.params); err == nil {
+					validParams = true
+					err = handler.Func(context, handler.params)
+				}
+			}
+		}
+
 	}
 
 	return
+}
+
+func (self *Handler) FindCustomRequestHandler(method string) (*CustomRequestHandler, bool) {
+	for _, handler := range self.CustomRequest {
+		if handler.Method == method {
+			return &handler, true
+		}
+	}
+	return nil, false
 }
 
 func (self *Handler) IsInitialized() bool {

--- a/protocol_3_17/custom.go
+++ b/protocol_3_17/custom.go
@@ -1,0 +1,15 @@
+package protocol
+
+import (
+	"encoding/json"
+
+	"github.com/tliron/glsp"
+)
+
+type CustomRequestHandler struct {
+	Method string
+	Func   CustomRequestFunc
+	params json.RawMessage
+}
+
+type CustomRequestFunc func(context *glsp.Context, params json.RawMessage) error

--- a/protocol_3_17/handler.go
+++ b/protocol_3_17/handler.go
@@ -648,10 +648,30 @@ func (self *Handler) Handle(context *glsp.Context) (r any, validMethod bool, val
 				r, err = self.TextDocumentDiagnostic(context, &params)
 			}
 		}
+
+	default:
+		if self.CustomRequest != nil {
+			if handler, ok := self.FindCustomRequestHandler(context.Method); ok {
+				validMethod = true
+				if err = json.Unmarshal(context.Params, &handler.params); err == nil {
+					validParams = true
+					err = handler.Func(context, handler.params)
+				}
+			}
+		}
+
 	}
 
 	return
+}
 
+func (self *Handler) FindCustomRequestHandler(method string) (*CustomRequestHandler, bool) {
+	for _, handler := range self.CustomRequest {
+		if handler.Method == method {
+			return &handler, true
+		}
+	}
+	return nil, false
 }
 
 func (self *Handler) IsInitialized() bool {

--- a/server/handler.go
+++ b/server/handler.go
@@ -37,8 +37,11 @@ func (self *Server) handle(context contextpkg.Context, connection *jsonrpc2.Conn
 	switch request.Method {
 	case "exit":
 		// We're giving the attached handler a chance to handle it first, but we'll ignore any result
-		self.Handler.Handle(&glspContext)
-		err := connection.Close()
+		_, _, _, err := self.Handler.Handle(&glspContext)
+		if err != nil {
+			return nil, err
+		}
+		err = connection.Close()
 		return nil, err
 
 	default:


### PR DESCRIPTION
This commit introduces the ability to handle custom requests in the protocol package. A new struct, CustomRequestHandler, has been added which contains a Method and a Func. The Func is a function that takes a context and params and returns an error.

The Handler struct now includes a slice of CustomRequestHandlers, and the Handle method has been updated to handle custom requests by unmarshalling the params into the handler's params and then calling the handler's Func.

A new method, FindCustomRequestHandler, has been added to the Handler struct. This method takes a method string and returns the corresponding CustomRequestHandler and a boolean indicating whether the handler was found.

The server's handle method has also been updated to handle errors from the Handler's Handle method.

Usage example:



