### PR TITLE
Support textDocument/inlineCompletion request from 3.18

### DIFF
--- a/protocol_3_18/general-messages.go
+++ b/protocol_3_18/general-messages.go
@@ -1,0 +1,487 @@
+package protocol
+
+import (
+	"encoding/json"
+
+	"github.com/tliron/glsp"
+	protocol316 "github.com/tliron/glsp/protocol_3_16"
+	protocol317 "github.com/tliron/glsp/protocol_3_17"
+)
+
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#initialize
+
+const MethodInitialize = protocol317.MethodInitialize
+
+// Returns: InitializeResult | InitializeError
+type InitializeFunc func(context *glsp.Context, params *InitializeParams) (any, error)
+
+type InitializeParams struct {
+	protocol317.InitializeParams
+
+	/**
+	 * The capabilities provided by the client (editor or tool)
+	 */
+	Capabilities ClientCapabilities `json:"capabilities"`
+}
+
+type ClientCapabilities struct {
+	protocol317.ClientCapabilities
+
+	TextDocument *TextDocumentClientCapabilities `json:"textDocument,omitempty"`
+}
+
+/**
+ * Text document specific client capabilities.
+ */
+type TextDocumentClientCapabilities struct {
+	protocol317.TextDocumentClientCapabilities
+
+	/**
+	 * Capabilities specific to inline completions.
+	 *
+	 * @since 3.18.0
+	 */
+	InlineCompletion *InlineCompletionClientCapabilities `json:"inlineCompletion,omitempty"`
+}
+
+type ServerCapabilities struct {
+	protocol317.ServerCapabilities
+
+	/**
+	 * The server has support for inline completions.
+	 *
+	 * @since 3.18.0
+	 */
+	InlineCompletionProvider any `json:"inlineCompletionProvider,omitempty"` // nil | bool | InlineCompletionOptions
+}
+
+func (self *ServerCapabilities) UnmarshalJSON(data []byte) error {
+	var value struct {
+		TextDocumentSync                 json.RawMessage                              `json:"textDocumentSync,omitempty"` // nil | TextDocumentSyncOptions | TextDocumentSyncKind
+		CompletionProvider               *protocol316.CompletionOptions               `json:"completionProvider,omitempty"`
+		HoverProvider                    json.RawMessage                              `json:"hoverProvider,omitempty"` // nil | bool | HoverOptions
+		SignatureHelpProvider            *protocol316.SignatureHelpOptions            `json:"signatureHelpProvider,omitempty"`
+		DeclarationProvider              json.RawMessage                              `json:"declarationProvider,omitempty"`       // nil | bool | DeclarationOptions | DeclarationRegistrationOptions
+		DefinitionProvider               json.RawMessage                              `json:"definitionProvider,omitempty"`        // nil | bool | DefinitionOptions
+		TypeDefinitionProvider           json.RawMessage                              `json:"typeDefinitionProvider,omitempty"`    // nil | bool | TypeDefinitionOption | TypeDefinitionRegistrationOptions
+		ImplementationProvider           json.RawMessage                              `json:"implementationProvider,omitempty"`    // nil | bool | ImplementationOptions | ImplementationRegistrationOptions
+		ReferencesProvider               json.RawMessage                              `json:"referencesProvider,omitempty"`        // nil | bool | ReferenceOptions
+		DocumentHighlightProvider        json.RawMessage                              `json:"documentHighlightProvider,omitempty"` // nil | bool | DocumentHighlightOptions
+		DocumentSymbolProvider           json.RawMessage                              `json:"documentSymbolProvider,omitempty"`    // nil | bool | DocumentSymbolOptions
+		CodeActionProvider               json.RawMessage                              `json:"codeActionProvider,omitempty"`        // nil | bool | CodeActionOptions
+		CodeLensProvider                 *protocol316.CodeLensOptions                 `json:"codeLensProvider,omitempty"`
+		DocumentLinkProvider             *protocol316.DocumentLinkOptions             `json:"documentLinkProvider,omitempty"`
+		ColorProvider                    json.RawMessage                              `json:"colorProvider,omitempty"`                   // nil | bool | DocumentColorOptions | DocumentColorRegistrationOptions
+		DocumentFormattingProvider       json.RawMessage                              `json:"documentFormattingProvider,omitempty"`      // nil | bool | DocumentFormattingOptions
+		DocumentRangeFormattingProvider  json.RawMessage                              `json:"documentRangeFormattingProvider,omitempty"` // nil | bool | DocumentRangeFormattingOptions
+		DocumentOnTypeFormattingProvider *protocol316.DocumentOnTypeFormattingOptions `json:"documentOnTypeFormattingProvider,omitempty"`
+		RenameProvider                   json.RawMessage                              `json:"renameProvider,omitempty"`       // nil | bool | RenameOptions
+		FoldingRangeProvider             json.RawMessage                              `json:"foldingRangeProvider,omitempty"` // nil | bool | FoldingRangeOptions | FoldingRangeRegistrationOptions
+		ExecuteCommandProvider           *protocol316.ExecuteCommandOptions           `json:"executeCommandProvider,omitempty"`
+		SelectionRangeProvider           json.RawMessage                              `json:"selectionRangeProvider,omitempty"`     // nil | bool | SelectionRangeOptions | SelectionRangeRegistrationOptions
+		LinkedEditingRangeProvider       json.RawMessage                              `json:"linkedEditingRangeProvider,omitempty"` // nil | bool | LinkedEditingRangeOptions | LinkedEditingRangeRegistrationOptions
+		CallHierarchyProvider            json.RawMessage                              `json:"callHierarchyProvider,omitempty"`      // nil | bool | CallHierarchyOptions | CallHierarchyRegistrationOptions
+		SemanticTokensProvider           json.RawMessage                              `json:"semanticTokensProvider,omitempty"`     // nil | SemanticTokensOptions | SemanticTokensRegistrationOptions
+		MonikerProvider                  json.RawMessage                              `json:"monikerProvider,omitempty"`            // nil | bool | MonikerOptions | MonikerRegistrationOptions
+		WorkspaceSymbolProvider          json.RawMessage                              `json:"workspaceSymbolProvider,omitempty"`    // nil | bool | WorkspaceSymbolOptions
+		Workspace                        *protocol316.ServerCapabilitiesWorkspace     `json:"workspace,omitempty"`
+		Experimental                     *any                                         `json:"experimental,omitempty"`
+		DiagnosticProvider               json.RawMessage                              `json:"diagnosticProvider,omitempty"`       // nil | DiagnosticOptions | DiagnosticRegistrationOptions
+		InlineCompletionProvider         json.RawMessage                              `json:"inlineCompletionProvider,omitempty"` // nil | bool | InlineCompletionOptions
+	}
+
+	if err := json.Unmarshal(data, &value); err == nil {
+		self.CompletionProvider = value.CompletionProvider
+		self.SignatureHelpProvider = value.SignatureHelpProvider
+		self.CodeLensProvider = value.CodeLensProvider
+		self.DocumentLinkProvider = value.DocumentLinkProvider
+		self.DocumentOnTypeFormattingProvider = value.DocumentOnTypeFormattingProvider
+		self.ExecuteCommandProvider = value.ExecuteCommandProvider
+		self.Workspace = value.Workspace
+
+		if value.TextDocumentSync != nil {
+			var value_ protocol316.TextDocumentSyncOptions
+			if err = json.Unmarshal(value.TextDocumentSync, &value_); err == nil {
+				self.TextDocumentSync = value_
+			} else {
+				var value_ protocol316.TextDocumentSyncKind
+				if err = json.Unmarshal(value.TextDocumentSync, &value_); err == nil {
+					self.TextDocumentSync = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.HoverProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.HoverProvider, &value_); err == nil {
+				self.HoverProvider = value_
+			} else {
+				var value_ protocol316.HoverOptions
+				if err = json.Unmarshal(value.HoverProvider, &value_); err == nil {
+					self.HoverProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.DeclarationProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DeclarationProvider, &value_); err == nil {
+				self.DeclarationProvider = value_
+			} else {
+				var value_ protocol316.DeclarationOptions
+				if err = json.Unmarshal(value.DeclarationProvider, &value_); err == nil {
+					self.DeclarationProvider = value_
+				} else {
+					var value_ protocol316.DeclarationRegistrationOptions
+					if err = json.Unmarshal(value.DeclarationProvider, &value_); err == nil {
+						self.DeclarationProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.DefinitionProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DefinitionProvider, &value_); err == nil {
+				self.DefinitionProvider = value_
+			} else {
+				var value_ protocol316.DefinitionOptions
+				if err = json.Unmarshal(value.DefinitionProvider, &value_); err == nil {
+					self.DefinitionProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.TypeDefinitionProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.TypeDefinitionProvider, &value_); err == nil {
+				self.TypeDefinitionProvider = value_
+			} else {
+				var value_ protocol316.TypeDefinitionOptions
+				if err = json.Unmarshal(value.TypeDefinitionProvider, &value_); err == nil {
+					self.TypeDefinitionProvider = value_
+				} else {
+					var value_ protocol316.TypeDefinitionRegistrationOptions
+					if err = json.Unmarshal(value.TypeDefinitionProvider, &value_); err == nil {
+						self.TypeDefinitionProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.ImplementationProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.ImplementationProvider, &value_); err == nil {
+				self.ImplementationProvider = value_
+			} else {
+				var value_ protocol316.ImplementationOptions
+				if err = json.Unmarshal(value.ImplementationProvider, &value_); err == nil {
+					self.ImplementationProvider = value_
+				} else {
+					var value_ protocol316.ImplementationRegistrationOptions
+					if err = json.Unmarshal(value.ImplementationProvider, &value_); err == nil {
+						self.ImplementationProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.ReferencesProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.ReferencesProvider, &value_); err == nil {
+				self.ReferencesProvider = value_
+			} else {
+				var value_ protocol316.ReferenceOptions
+				if err = json.Unmarshal(value.ReferencesProvider, &value_); err == nil {
+					self.ReferencesProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.DocumentHighlightProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DocumentHighlightProvider, &value_); err == nil {
+				self.DocumentHighlightProvider = value_
+			} else {
+				var value_ protocol316.DocumentHighlightOptions
+				if err = json.Unmarshal(value.DocumentHighlightProvider, &value_); err == nil {
+					self.DocumentHighlightProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.DocumentSymbolProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DocumentSymbolProvider, &value_); err == nil {
+				self.DocumentSymbolProvider = value_
+			} else {
+				var value_ protocol316.DocumentSymbolOptions
+				if err = json.Unmarshal(value.DocumentSymbolProvider, &value_); err == nil {
+					self.DocumentSymbolProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.CodeActionProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.CodeActionProvider, &value_); err == nil {
+				self.CodeActionProvider = value_
+			} else {
+				var value_ protocol316.CodeActionOptions
+				if err = json.Unmarshal(value.CodeActionProvider, &value_); err == nil {
+					self.CodeActionProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.ColorProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.ColorProvider, &value_); err == nil {
+				self.ColorProvider = value_
+			} else {
+				var value_ protocol316.DocumentColorOptions
+				if err = json.Unmarshal(value.ColorProvider, &value_); err == nil {
+					self.ColorProvider = value_
+				} else {
+					var value_ protocol316.DocumentColorRegistrationOptions
+					if err = json.Unmarshal(value.ColorProvider, &value_); err == nil {
+						self.ColorProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.DocumentFormattingProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DocumentFormattingProvider, &value_); err == nil {
+				self.DocumentFormattingProvider = value_
+			} else {
+				var value_ protocol316.DocumentFormattingOptions
+				if err = json.Unmarshal(value.DocumentFormattingProvider, &value_); err == nil {
+					self.DocumentFormattingProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.DocumentRangeFormattingProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.DocumentRangeFormattingProvider, &value_); err == nil {
+				self.DocumentRangeFormattingProvider = value_
+			} else {
+				var value_ protocol316.DocumentRangeFormattingOptions
+				if err = json.Unmarshal(value.DocumentRangeFormattingProvider, &value_); err == nil {
+					self.DocumentRangeFormattingProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.RenameProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.RenameProvider, &value_); err == nil {
+				self.RenameProvider = value_
+			} else {
+				var value_ protocol316.RenameOptions
+				if err = json.Unmarshal(value.RenameProvider, &value_); err == nil {
+					self.RenameProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.FoldingRangeProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.FoldingRangeProvider, &value_); err == nil {
+				self.FoldingRangeProvider = value_
+			} else {
+				var value_ protocol316.FoldingRangeOptions
+				if err = json.Unmarshal(value.FoldingRangeProvider, &value_); err == nil {
+					self.FoldingRangeProvider = value_
+				} else {
+					var value_ protocol316.FoldingRangeRegistrationOptions
+					if err = json.Unmarshal(value.FoldingRangeProvider, &value_); err == nil {
+						self.FoldingRangeProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.SelectionRangeProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.SelectionRangeProvider, &value_); err == nil {
+				self.SelectionRangeProvider = value_
+			} else {
+				var value_ protocol316.SelectionRangeOptions
+				if err = json.Unmarshal(value.SelectionRangeProvider, &value_); err == nil {
+					self.SelectionRangeProvider = value_
+				} else {
+					var value_ protocol316.SelectionRangeRegistrationOptions
+					if err = json.Unmarshal(value.SelectionRangeProvider, &value_); err == nil {
+						self.SelectionRangeProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.LinkedEditingRangeProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.LinkedEditingRangeProvider, &value_); err == nil {
+				self.LinkedEditingRangeProvider = value_
+			} else {
+				var value_ protocol316.LinkedEditingRangeOptions
+				if err = json.Unmarshal(value.LinkedEditingRangeProvider, &value_); err == nil {
+					self.LinkedEditingRangeProvider = value_
+				} else {
+					var value_ protocol316.LinkedEditingRangeRegistrationOptions
+					if err = json.Unmarshal(value.LinkedEditingRangeProvider, &value_); err == nil {
+						self.LinkedEditingRangeProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.CallHierarchyProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.CallHierarchyProvider, &value_); err == nil {
+				self.CallHierarchyProvider = value_
+			} else {
+				var value_ protocol316.CallHierarchyOptions
+				if err = json.Unmarshal(value.CallHierarchyProvider, &value_); err == nil {
+					self.CallHierarchyProvider = value_
+				} else {
+					var value_ protocol316.CallHierarchyRegistrationOptions
+					if err = json.Unmarshal(value.CallHierarchyProvider, &value_); err == nil {
+						self.CallHierarchyProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.SemanticTokensProvider != nil {
+			var value_ protocol316.SemanticTokensOptions
+			if err = json.Unmarshal(value.SemanticTokensProvider, &value_); err == nil {
+				self.SemanticTokensProvider = value_
+			} else {
+				var value_ protocol316.SemanticTokensRegistrationOptions
+				if err = json.Unmarshal(value.SemanticTokensProvider, &value_); err == nil {
+					self.SemanticTokensProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.MonikerProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.MonikerProvider, &value_); err == nil {
+				self.MonikerProvider = value_
+			} else {
+				var value_ protocol316.MonikerOptions
+				if err = json.Unmarshal(value.MonikerProvider, &value_); err == nil {
+					self.MonikerProvider = value_
+				} else {
+					var value_ protocol316.MonikerRegistrationOptions
+					if err = json.Unmarshal(value.MonikerProvider, &value_); err == nil {
+						self.MonikerProvider = value_
+					} else {
+						return err
+					}
+				}
+			}
+		}
+
+		if value.WorkspaceSymbolProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.WorkspaceSymbolProvider, &value_); err == nil {
+				self.WorkspaceSymbolProvider = value_
+			} else {
+				var value_ protocol316.WorkspaceSymbolOptions
+				if err = json.Unmarshal(value.WorkspaceSymbolProvider, &value_); err == nil {
+					self.WorkspaceSymbolProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.DiagnosticProvider != nil {
+			var value_ protocol317.DiagnosticOptions
+			if err = json.Unmarshal(value.DiagnosticProvider, &value_); err == nil {
+				self.DiagnosticProvider = value_
+			} else {
+				var value_ protocol317.DiagnosticRegistrationOptions
+				if err = json.Unmarshal(value.DiagnosticProvider, &value_); err == nil {
+					self.DiagnosticProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		if value.InlineCompletionProvider != nil {
+			var value_ bool
+			if err = json.Unmarshal(value.InlineCompletionProvider, &value_); err == nil {
+				self.InlineCompletionProvider = value_
+			} else {
+				var value_ InlineCompletionOptions
+				if err = json.Unmarshal(value.InlineCompletionProvider, &value_); err == nil {
+					self.InlineCompletionProvider = value_
+				} else {
+					return err
+				}
+			}
+		}
+
+		return nil
+	} else {
+		return err
+	}
+}
+
+type InitializeResult struct {
+	/**
+	 * The capabilities the language server provides.
+	 */
+	Capabilities ServerCapabilities `json:"capabilities"`
+
+	/**
+	 * Information about the server.
+	 *
+	 * @since 3.15.0
+	 */
+	ServerInfo *protocol316.InitializeResultServerInfo `json:"serverInfo,omitempty"`
+}

--- a/protocol_3_18/handler.go
+++ b/protocol_3_18/handler.go
@@ -1,0 +1,928 @@
+package protocol
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/tliron/glsp"
+	protocol316 "github.com/tliron/glsp/protocol_3_16"
+	protocol317 "github.com/tliron/glsp/protocol_3_17"
+)
+
+type Handler struct {
+	protocol317.Handler
+
+	Initialize                   InitializeFunc
+	TextDocumentInlineCompletion TextDocumentInlineCompletionFunc
+
+	initialized bool
+	lock        sync.Mutex
+}
+
+func (self *Handler) Handle(context *glsp.Context) (r any, validMethod bool, validParams bool, err error) {
+	if !self.IsInitialized() && (context.Method != protocol316.MethodInitialize) {
+		return nil, true, true, errors.New("server not initialized")
+	}
+
+	switch context.Method {
+	case protocol316.MethodCancelRequest:
+		if self.CancelRequest != nil {
+			validMethod = true
+			var params protocol316.CancelParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.CancelRequest(context, &params)
+			}
+		}
+
+	case protocol316.MethodProgress:
+		if self.Progress != nil {
+			validMethod = true
+			var params protocol316.ProgressParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.Progress(context, &params)
+			}
+		}
+
+	// General Messages
+
+	case MethodInitialize:
+		if self.Initialize != nil {
+			validMethod = true
+			var params InitializeParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				if r, err = self.Initialize(context, &params); err == nil {
+					self.SetInitialized(true)
+				}
+			}
+		}
+
+	case protocol316.MethodInitialized:
+		if self.Initialized != nil {
+			validMethod = true
+			var params protocol316.InitializedParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.Initialized(context, &params)
+			}
+		}
+
+	case protocol316.MethodShutdown:
+		self.SetInitialized(false)
+		if self.Shutdown != nil {
+			validMethod = true
+			validParams = true
+			err = self.Shutdown(context)
+		}
+
+	case protocol316.MethodExit:
+		// Note that the server will close the connection after we handle it here
+		if self.Exit != nil {
+			validMethod = true
+			validParams = true
+			err = self.Exit(context)
+		}
+
+	case protocol316.MethodLogTrace:
+		if self.LogTrace != nil {
+			validMethod = true
+			var params protocol316.LogTraceParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.LogTrace(context, &params)
+			}
+		}
+
+	case protocol316.MethodSetTrace:
+		if self.SetTrace != nil {
+			validMethod = true
+			var params protocol316.SetTraceParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.SetTrace(context, &params)
+			}
+		}
+
+	// Window
+
+	case protocol316.MethodWindowWorkDoneProgressCancel:
+		if self.WindowWorkDoneProgressCancel != nil {
+			validMethod = true
+			var params protocol316.WorkDoneProgressCancelParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WindowWorkDoneProgressCancel(context, &params)
+			}
+		}
+
+	// Workspace
+
+	case protocol316.MethodWorkspaceDidChangeWorkspaceFolders:
+		if self.WorkspaceDidChangeWorkspaceFolders != nil {
+			validMethod = true
+			var params protocol316.DidChangeWorkspaceFoldersParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidChangeWorkspaceFolders(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceDidChangeConfiguration:
+		if self.WorkspaceDidChangeConfiguration != nil {
+			validMethod = true
+			var params protocol316.DidChangeConfigurationParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidChangeConfiguration(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceDidChangeWatchedFiles:
+		if self.WorkspaceDidChangeWatchedFiles != nil {
+			validMethod = true
+			var params protocol316.DidChangeWatchedFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidChangeWatchedFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceSymbol:
+		if self.WorkspaceSymbol != nil {
+			validMethod = true
+			var params protocol316.WorkspaceSymbolParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.WorkspaceSymbol(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceExecuteCommand:
+		if self.WorkspaceExecuteCommand != nil {
+			validMethod = true
+			var params protocol316.ExecuteCommandParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.WorkspaceExecuteCommand(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceWillCreateFiles:
+		if self.WorkspaceWillCreateFiles != nil {
+			validMethod = true
+			var params protocol316.CreateFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.WorkspaceWillCreateFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceDidCreateFiles:
+		if self.WorkspaceDidCreateFiles != nil {
+			validMethod = true
+			var params protocol316.CreateFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidCreateFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceWillRenameFiles:
+		if self.WorkspaceWillRenameFiles != nil {
+			validMethod = true
+			var params protocol316.RenameFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.WorkspaceWillRenameFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceDidRenameFiles:
+		if self.WorkspaceDidRenameFiles != nil {
+			validMethod = true
+			var params protocol316.RenameFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidRenameFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceWillDeleteFiles:
+		if self.WorkspaceWillDeleteFiles != nil {
+			validMethod = true
+			var params protocol316.DeleteFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.WorkspaceWillDeleteFiles(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceDidDeleteFiles:
+		if self.WorkspaceDidDeleteFiles != nil {
+			validMethod = true
+			var params protocol316.DeleteFilesParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.WorkspaceDidDeleteFiles(context, &params)
+			}
+		}
+
+	// Text Document Synchronization
+
+	case protocol316.MethodTextDocumentDidOpen:
+		if self.TextDocumentDidOpen != nil {
+			validMethod = true
+			var params protocol316.DidOpenTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.TextDocumentDidOpen(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDidChange:
+		if self.TextDocumentDidChange != nil {
+			validMethod = true
+			var params protocol316.DidChangeTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.TextDocumentDidChange(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentWillSave:
+		if self.TextDocumentWillSave != nil {
+			validMethod = true
+			var params protocol316.WillSaveTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.TextDocumentWillSave(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentWillSaveWaitUntil:
+		if self.TextDocumentWillSaveWaitUntil != nil {
+			validMethod = true
+			var params protocol316.WillSaveTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentWillSaveWaitUntil(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDidSave:
+		if self.TextDocumentDidSave != nil {
+			validMethod = true
+			var params protocol316.DidSaveTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.TextDocumentDidSave(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDidClose:
+		if self.TextDocumentDidClose != nil {
+			validMethod = true
+			var params protocol316.DidCloseTextDocumentParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				err = self.TextDocumentDidClose(context, &params)
+			}
+		}
+
+	// Language Features
+
+	case protocol316.MethodTextDocumentCompletion:
+		if self.TextDocumentCompletion != nil {
+			validMethod = true
+			var params protocol316.CompletionParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentCompletion(context, &params)
+			}
+		}
+
+	case protocol316.MethodCompletionItemResolve:
+		if self.CompletionItemResolve != nil {
+			validMethod = true
+			var params protocol316.CompletionItem
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.CompletionItemResolve(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentHover:
+		if self.TextDocumentHover != nil {
+			validMethod = true
+			var params protocol316.HoverParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentHover(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentSignatureHelp:
+		if self.TextDocumentSignatureHelp != nil {
+			validMethod = true
+			var params protocol316.SignatureHelpParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentSignatureHelp(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDeclaration:
+		if self.TextDocumentDeclaration != nil {
+			validMethod = true
+			var params protocol316.DeclarationParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDeclaration(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDefinition:
+		if self.TextDocumentDefinition != nil {
+			validMethod = true
+			var params protocol316.DefinitionParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDefinition(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentTypeDefinition:
+		if self.TextDocumentTypeDefinition != nil {
+			validMethod = true
+			var params protocol316.TypeDefinitionParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentTypeDefinition(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentImplementation:
+		if self.TextDocumentImplementation != nil {
+			validMethod = true
+			var params protocol316.ImplementationParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentImplementation(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentReferences:
+		if self.TextDocumentReferences != nil {
+			validMethod = true
+			var params protocol316.ReferenceParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentReferences(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDocumentHighlight:
+		if self.TextDocumentDocumentHighlight != nil {
+			validMethod = true
+			var params protocol316.DocumentHighlightParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDocumentHighlight(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDocumentSymbol:
+		if self.TextDocumentDocumentSymbol != nil {
+			validMethod = true
+			var params protocol316.DocumentSymbolParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDocumentSymbol(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentCodeAction:
+		if self.TextDocumentCodeAction != nil {
+			validMethod = true
+			var params protocol316.CodeActionParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentCodeAction(context, &params)
+			}
+		}
+
+	case protocol316.MethodCodeActionResolve:
+		if self.CodeActionResolve != nil {
+			validMethod = true
+			var params protocol316.CodeAction
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.CodeActionResolve(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentCodeLens:
+		if self.TextDocumentCodeLens != nil {
+			validMethod = true
+			var params protocol316.CodeLensParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentCodeLens(context, &params)
+			}
+		}
+
+	case protocol316.MethodCodeLensResolve:
+		if self.TextDocumentDidClose != nil {
+			validMethod = true
+			var params protocol316.CodeLens
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.CodeLensResolve(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentDocumentLink:
+		if self.TextDocumentDocumentLink != nil {
+			validMethod = true
+			var params protocol316.DocumentLinkParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDocumentLink(context, &params)
+			}
+		}
+
+	case protocol316.MethodDocumentLinkResolve:
+		if self.DocumentLinkResolve != nil {
+			validMethod = true
+			var params protocol316.DocumentLink
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.DocumentLinkResolve(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentColor:
+		if self.TextDocumentColor != nil {
+			validMethod = true
+			var params protocol316.DocumentColorParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentColor(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentColorPresentation:
+		if self.TextDocumentColorPresentation != nil {
+			validMethod = true
+			var params protocol316.ColorPresentationParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentColorPresentation(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentFormatting:
+		if self.TextDocumentFormatting != nil {
+			validMethod = true
+			var params protocol316.DocumentFormattingParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentFormatting(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentRangeFormatting:
+		if self.TextDocumentRangeFormatting != nil {
+			validMethod = true
+			var params protocol316.DocumentRangeFormattingParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentRangeFormatting(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentOnTypeFormatting:
+		if self.TextDocumentOnTypeFormatting != nil {
+			validMethod = true
+			var params protocol316.DocumentOnTypeFormattingParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentOnTypeFormatting(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentRename:
+		if self.TextDocumentRename != nil {
+			validMethod = true
+			var params protocol316.RenameParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentRename(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentPrepareRename:
+		if self.TextDocumentPrepareRename != nil {
+			validMethod = true
+			var params protocol316.PrepareRenameParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentPrepareRename(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentFoldingRange:
+		if self.TextDocumentFoldingRange != nil {
+			validMethod = true
+			var params protocol316.FoldingRangeParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentFoldingRange(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentSelectionRange:
+		if self.TextDocumentSelectionRange != nil {
+			validMethod = true
+			var params protocol316.SelectionRangeParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentSelectionRange(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentPrepareCallHierarchy:
+		if self.TextDocumentPrepareCallHierarchy != nil {
+			validMethod = true
+			var params protocol316.CallHierarchyPrepareParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentPrepareCallHierarchy(context, &params)
+			}
+		}
+
+	case protocol316.MethodCallHierarchyIncomingCalls:
+		if self.CallHierarchyIncomingCalls != nil {
+			validMethod = true
+			var params protocol316.CallHierarchyIncomingCallsParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.CallHierarchyIncomingCalls(context, &params)
+			}
+		}
+
+	case protocol316.MethodCallHierarchyOutgoingCalls:
+		if self.CallHierarchyOutgoingCalls != nil {
+			validMethod = true
+			var params protocol316.CallHierarchyOutgoingCallsParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.CallHierarchyOutgoingCalls(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentSemanticTokensFull:
+		if self.TextDocumentSemanticTokensFull != nil {
+			validMethod = true
+			var params protocol316.SemanticTokensParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentSemanticTokensFull(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentSemanticTokensFullDelta:
+		if self.TextDocumentSemanticTokensFullDelta != nil {
+			validMethod = true
+			var params protocol316.SemanticTokensDeltaParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentSemanticTokensFullDelta(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentSemanticTokensRange:
+		if self.TextDocumentSemanticTokensRange != nil {
+			validMethod = true
+			var params protocol316.SemanticTokensRangeParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentSemanticTokensRange(context, &params)
+			}
+		}
+
+	case protocol316.MethodWorkspaceSemanticTokensRefresh:
+		if self.WorkspaceSemanticTokensRefresh != nil {
+			validMethod = true
+			validParams = true
+			err = self.WorkspaceSemanticTokensRefresh(context)
+		}
+
+	case protocol316.MethodTextDocumentLinkedEditingRange:
+		if self.TextDocumentLinkedEditingRange != nil {
+			validMethod = true
+			var params protocol316.LinkedEditingRangeParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentLinkedEditingRange(context, &params)
+			}
+		}
+
+	case protocol316.MethodTextDocumentMoniker:
+		if self.TextDocumentMoniker != nil {
+			validMethod = true
+			var params protocol316.MonikerParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentMoniker(context, &params)
+			}
+		}
+
+	case protocol317.MethodTextDocumentDiagnostic:
+		if self.TextDocumentDiagnostic != nil {
+			validMethod = true
+			var params protocol317.DocumentDiagnosticParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentDiagnostic(context, &params)
+			}
+		}
+
+	case MethodTextDocumentInlineCompletion:
+		if self.TextDocumentInlineCompletion != nil {
+			validMethod = true
+			var params InlineCompletionParams
+			if err = json.Unmarshal(context.Params, &params); err == nil {
+				validParams = true
+				r, err = self.TextDocumentInlineCompletion(context, &params)
+			}
+		}
+	}
+
+	return
+
+}
+
+func (self *Handler) IsInitialized() bool {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	return self.initialized
+}
+
+func (self *Handler) SetInitialized(initialized bool) {
+	self.lock.Lock()
+	defer self.lock.Unlock()
+	self.initialized = initialized
+}
+
+func (self *Handler) CreateServerCapabilities() ServerCapabilities {
+	var capabilities ServerCapabilities
+
+	if (self.TextDocumentDidOpen != nil) || (self.TextDocumentDidClose != nil) {
+		if _, ok := capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions); !ok {
+			capabilities.TextDocumentSync = &protocol316.TextDocumentSyncOptions{}
+		}
+		capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions).OpenClose = &protocol316.True
+	}
+
+	if self.TextDocumentDidChange != nil {
+		if _, ok := capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions); !ok {
+			capabilities.TextDocumentSync = &protocol316.TextDocumentSyncOptions{}
+		}
+		// This can be overriden to TextDocumentSyncKindFull
+		value := protocol316.TextDocumentSyncKindIncremental
+		capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions).Change = &value
+	}
+
+	if self.TextDocumentWillSave != nil {
+		if _, ok := capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions); !ok {
+			capabilities.TextDocumentSync = &protocol316.TextDocumentSyncOptions{}
+		}
+		capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions).WillSave = &protocol316.True
+	}
+
+	if self.TextDocumentWillSaveWaitUntil != nil {
+		if _, ok := capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions); !ok {
+			capabilities.TextDocumentSync = &protocol316.TextDocumentSyncOptions{}
+		}
+		capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions).WillSaveWaitUntil = &protocol316.True
+	}
+
+	if self.TextDocumentDidSave != nil {
+		if _, ok := capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions); !ok {
+			capabilities.TextDocumentSync = &protocol316.TextDocumentSyncOptions{}
+		}
+		capabilities.TextDocumentSync.(*protocol316.TextDocumentSyncOptions).Save = &protocol316.True
+	}
+
+	if self.TextDocumentCompletion != nil {
+		capabilities.CompletionProvider = &protocol316.CompletionOptions{}
+	}
+
+	if self.TextDocumentHover != nil {
+		capabilities.HoverProvider = true
+	}
+
+	if self.TextDocumentSignatureHelp != nil {
+		capabilities.SignatureHelpProvider = &protocol316.SignatureHelpOptions{}
+	}
+
+	if self.TextDocumentDeclaration != nil {
+		capabilities.DeclarationProvider = true
+	}
+
+	if self.TextDocumentDefinition != nil {
+		capabilities.DefinitionProvider = true
+	}
+
+	if self.TextDocumentTypeDefinition != nil {
+		capabilities.TypeDefinitionProvider = true
+	}
+
+	if self.TextDocumentImplementation != nil {
+		capabilities.ImplementationProvider = true
+	}
+
+	if self.TextDocumentReferences != nil {
+		capabilities.ReferencesProvider = true
+	}
+
+	if self.TextDocumentDocumentHighlight != nil {
+		capabilities.DocumentHighlightProvider = true
+	}
+
+	if self.TextDocumentDocumentSymbol != nil {
+		capabilities.DocumentSymbolProvider = true
+	}
+
+	if self.TextDocumentCodeAction != nil {
+		capabilities.CodeActionProvider = true
+	}
+
+	if self.TextDocumentCodeLens != nil {
+		capabilities.CodeLensProvider = &protocol316.CodeLensOptions{}
+	}
+
+	if self.TextDocumentDocumentLink != nil {
+		capabilities.DocumentLinkProvider = &protocol316.DocumentLinkOptions{}
+	}
+
+	if self.TextDocumentColor != nil {
+		capabilities.ColorProvider = true
+	}
+
+	if self.TextDocumentFormatting != nil {
+		capabilities.DocumentFormattingProvider = true
+	}
+
+	if self.TextDocumentRangeFormatting != nil {
+		capabilities.DocumentRangeFormattingProvider = true
+	}
+
+	if self.TextDocumentOnTypeFormatting != nil {
+		capabilities.DocumentOnTypeFormattingProvider = &protocol316.DocumentOnTypeFormattingOptions{}
+	}
+
+	if self.TextDocumentRename != nil {
+		capabilities.RenameProvider = true
+	}
+
+	if self.TextDocumentFoldingRange != nil {
+		capabilities.FoldingRangeProvider = true
+	}
+
+	if self.WorkspaceExecuteCommand != nil {
+		capabilities.ExecuteCommandProvider = &protocol316.ExecuteCommandOptions{}
+	}
+
+	if self.TextDocumentSelectionRange != nil {
+		capabilities.SelectionRangeProvider = true
+	}
+
+	if self.TextDocumentLinkedEditingRange != nil {
+		capabilities.LinkedEditingRangeProvider = true
+	}
+
+	if self.TextDocumentPrepareCallHierarchy != nil {
+		capabilities.CallHierarchyProvider = true
+	}
+
+	if self.TextDocumentSemanticTokensFull != nil {
+		if _, ok := capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions); !ok {
+			capabilities.SemanticTokensProvider = &protocol316.SemanticTokensOptions{}
+		}
+		if self.TextDocumentSemanticTokensFullDelta != nil {
+			capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions).Full = &protocol316.SemanticDelta{}
+			capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions).Full.(*protocol316.SemanticDelta).Delta = &protocol316.True
+		} else {
+			capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions).Full = true
+		}
+	}
+
+	if self.TextDocumentSemanticTokensRange != nil {
+		if _, ok := capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions); !ok {
+			capabilities.SemanticTokensProvider = &protocol316.SemanticTokensOptions{}
+		}
+		capabilities.SemanticTokensProvider.(*protocol316.SemanticTokensOptions).Range = true
+	}
+
+	// TODO: self.TextDocumentSemanticTokensRefresh?
+
+	if self.TextDocumentMoniker != nil {
+		capabilities.MonikerProvider = true
+	}
+
+	if self.WorkspaceSymbol != nil {
+		capabilities.WorkspaceSymbolProvider = true
+	}
+
+	if self.WorkspaceDidCreateFiles != nil {
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.DidCreate = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.WorkspaceWillCreateFiles != nil {
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.WillCreate = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.WorkspaceDidRenameFiles != nil {
+		capabilities.RenameProvider = true
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.DidRename = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.WorkspaceWillRenameFiles != nil {
+		capabilities.RenameProvider = true
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.WillRename = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.WorkspaceDidDeleteFiles != nil {
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.DidDelete = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.WorkspaceWillDeleteFiles != nil {
+		if capabilities.Workspace == nil {
+			capabilities.Workspace = &protocol316.ServerCapabilitiesWorkspace{}
+		}
+		if capabilities.Workspace.FileOperations == nil {
+			capabilities.Workspace.FileOperations = &protocol316.ServerCapabilitiesWorkspaceFileOperations{}
+		}
+		capabilities.Workspace.FileOperations.WillDelete = &protocol316.FileOperationRegistrationOptions{
+			Filters: []protocol316.FileOperationFilter{},
+		}
+	}
+
+	if self.TextDocumentDiagnostic != nil {
+		capabilities.DiagnosticProvider = protocol317.DiagnosticOptions{
+			InterFileDependencies: true,
+			WorkspaceDiagnostics:  false,
+		}
+	}
+
+	if self.TextDocumentInlineCompletion != nil {
+		capabilities.InlineCompletionProvider = true
+	}
+
+	return capabilities
+}

--- a/protocol_3_18/inline-completion.go
+++ b/protocol_3_18/inline-completion.go
@@ -1,0 +1,169 @@
+package protocol
+
+import (
+	"github.com/tliron/glsp"
+	protocol316 "github.com/tliron/glsp/protocol_3_16"
+)
+
+/**
+ * Client capabilities specific to inline completion requests.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionClientCapabilities struct {
+
+	/**
+	 * Whether implementation supports dynamic registration. If this is set to
+	 * `true` the client supports the new
+	 * `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	 * return value for the corresponding server capability as well.
+	 */
+	DynamicRegistration bool `json:"dynamicRegistration"`
+}
+
+/**
+ * Inline completion options.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionOptions struct {
+	protocol316.WorkDoneProgressOptions
+}
+
+/**
+ * Inline completion registration options.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionRegistrationOptions struct {
+	protocol316.TextDocumentRegistrationOptions
+	protocol316.StaticRegistrationOptions
+	InlineCompletionOptions
+}
+
+const MethodTextDocumentInlineCompletion = protocol316.Method("textDocument/inlineCompletion")
+
+// Returns: []InlineCompletionItem | InlineCompletionList | nil
+type TextDocumentInlineCompletionFunc func(context *glsp.Context, params *InlineCompletionParams) (any, error)
+
+/**
+ * Parameters of the inline completion request.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionParams struct {
+	protocol316.TextDocumentPositionParams
+	protocol316.WorkDoneProgressParams
+
+	Context InlineCompletionContext `json:"context"`
+}
+
+/**
+ * Provides information about the context in which an inline completion was
+ * requested.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionContext struct {
+	/**
+	 * Describes how the inline completion was triggered.
+	 */
+	InlineCompletionTriggerKind InlineCompletionTriggerKind `json:"inlineCompletionTriggerKind"`
+
+	/**
+	 * Provides information about the currently selected item in the
+	 * autocomplete widget if it is visible.
+	 *
+	 * If set, provided inline completions must extend the text of the
+	 * selected item and use the same range, otherwise they are not shown as
+	 * preview.
+	 * As an example, if the document text is `console.` and the selected item
+	 * is `.log` replacing the `.` in the document, the inline completion must
+	 * also replace `.` and start with `.log`, for example `.log()`.
+	 *
+	 * Inline completion providers are requested again whenever the selected
+	 * item changes.
+	 */
+	SelectedCompletionInfo *SelectedCompletionInfo `json:"selectedCompletionInfo:omitempty"`
+}
+
+/**
+ * The inline completion trigger kinds.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionTriggerKind protocol316.Integer
+
+const (
+	/**
+	 * Completion was triggered explicitly by a user gesture.
+	 * Return multiple completion items to enable cycling through them.
+	 */
+	InlineCompletionTriggerKindInvoked = InlineCompletionTriggerKind(1)
+
+	/**
+	 * Completion was triggered automatically while editing.
+	 * It is sufficient to return a single completion item in this case.
+	 */
+	InlineCompletionTriggerKindAutomatic = InlineCompletionTriggerKind(2)
+)
+
+/**
+ * @since 3.18.0
+ */
+type SelectedCompletionInfo struct {
+	Range protocol316.Range `json:"range"`
+
+	Text string `json:"text"`
+}
+
+/**
+ * Represents a collection of inline completion items to be
+ * presented in the editor.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionList struct {
+	/**
+	 * The inline completion items.
+	 */
+	InlineCompletionItem []InlineCompletionItem `json:"items"`
+}
+
+/**
+ * An inline completion item represents a text snippet that is proposed inline
+ * to complete text that is being typed.
+ *
+ * @since 3.18.0
+ */
+type InlineCompletionItem struct {
+	/**
+	 * The text to replace the range with. Must be set.
+	 * Is used both for the preview and the accept operation.
+	 */
+	InsertText string `json:"insertText"`
+
+	/**
+	 * A text that is used to decide if this inline completion should be
+	 * shown. When `falsy`, the InlineCompletionItem.insertText is used.
+	 *
+	 * An inline completion is shown if the text to replace is a prefix of the
+	 * filter text.
+	 */
+	FilterText *string `json:"filterText,omitempty"`
+
+	/**
+	 * The range to replace.
+	 * Must begin and end on the same line.
+	 *
+	 * Prefer replacements over insertions to provide a better experience when
+	 * the user deletes typed text.
+	 */
+	Range *protocol316.Range `json:"range,omitempty"`
+
+	/**
+	 * An optional Command that is executed *after* inserting this
+	 * completion.
+	 */
+	Command *protocol316.Command `json:"command,omitempty"`
+}


### PR DESCRIPTION
I used #30 as an example for adding support for the new `textDocument/inlineCompletion` request introduced in 3.18. @tliron I know copy/pasting isn't the best of ideas but it can help get people unblocked for now. What do you think?

I tested it by having Visual Studio Code connect to the language server below and triggering the `textDocument/inlineCompletion` request from the editor.

```Go
package main

import (
	"github.com/tliron/commonlog"
	"github.com/tliron/glsp"
	protocol316 "github.com/tliron/glsp/protocol_3_16"
	protocol317 "github.com/tliron/glsp/protocol_3_17"
	protocol318 "github.com/tliron/glsp/protocol_3_18"
	"github.com/tliron/glsp/server"
)

const lsName = "my language"

var (
	version string = "0.0.1"
	handler protocol318.Handler
)

func main() {
	// This increases logging verbosity (optional)
	commonlog.Configure(1, nil)

	handler = protocol318.Handler{
		Initialize: initialize,
		TextDocumentInlineCompletion: func(context *glsp.Context, params *protocol318.InlineCompletionParams) (any, error) {
			return []protocol318.InlineCompletionItem{
				{
					InsertText: "hello world",
					Range: &protocol316.Range{
						Start: protocol316.Position{
							Line:      0,
							Character: 0,
						},
						End: protocol316.Position{
							Line:      0,
							Character: 0,
						},
					},
				},
			}, nil
		},
		Handler: protocol317.Handler{
			Handler: protocol316.Handler{
				Initialized: initialized,
				Shutdown:    shutdown,
				SetTrace:    setTrace,
			},
		},
	}

	server := server.NewServer(&handler, lsName, false)

	server.RunStdio()
}

func initialize(context *glsp.Context, params *protocol318.InitializeParams) (any, error) {
	capabilities := handler.CreateServerCapabilities()

	return protocol318.InitializeResult{
		Capabilities: capabilities,
		ServerInfo: &protocol316.InitializeResultServerInfo{
			Name:    lsName,
			Version: &version,
		},
	}, nil
}

func initialized(context *glsp.Context, params *protocol316.InitializedParams) error {
	return nil
}

func shutdown(context *glsp.Context) error {
	protocol316.SetTraceValue(protocol316.TraceValueOff)
	return nil
}

func setTrace(context *glsp.Context, params *protocol316.SetTraceParams) error {
	protocol316.SetTraceValue(params.Value)
	return nil
}
```